### PR TITLE
Working example with adbc-driver-snowflake

### DIFF
--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -75,7 +75,7 @@
     }
    ],
    "source": [
-    "pl.read_database(\"SELECT * FROM DATA.DIAMONDS\", con).head()"
+    "pl.read_database(\"SELECT * FROM DATA.DIAMONDS\", con, engine="adbc").head()"
    ]
   }
  ],

--- a/notebook.ipynb
+++ b/notebook.ipynb
@@ -75,7 +75,7 @@
     }
    ],
    "source": [
-    "pl.read_database(\"SELECT * FROM DATA.DIAMONDS\", con, engine="adbc").head()"
+    "pl.read_database(\"SELECT * FROM DATA.DIAMONDS\", con, engine=\"adbc\").head()"
    ]
   }
  ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+adbc-driver-snowflake==1.0.0
 connectorx==0.3.3
 notebook==7.2.1
 polars==0.20.31


### PR DESCRIPTION
Are there any Snowflake server/client compatibility or runtime version dependencies I should be aware of? For my team's specific data warehouse solution and code, I could only get this working with the `adbc-driver-snowflake` engine.

When I use the default `connectorx`, I get the following error every time:

```
  File "/Users/nathan/code/src/github.com/REDACTED/scripts/examples/polars_snowflake.py", line 52, in <module>
    df = pl.read_database(query, connection=cxn_str, engine="connectorx")
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nathan/.pyenv/versions/REDACTED/lib/python3.11/site-packages/polars/utils/deprecation.py", line 93, in wrapper
    return function(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nathan/.pyenv/versions/REDACTED/lib/python3.11/site-packages/polars/io/database.py", line 122, in read_database
    return _read_sql_connectorx(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nathan/.pyenv/versions/vREDACTED/lib/python3.11/site-packages/polars/io/database.py", line 153, in _read_sql_connectorx
    tbl = cx.read_sql(
          ^^^^^^^^^^^^
  File "/Users/nathan/.pyenv/versions/REDACTED/lib/python3.11/site-packages/connectorx/__init__.py", line 386, in read_sql
    result = _read_sql(
             ^^^^^^^^^^
RuntimeError: Source Unknown not supported.
```